### PR TITLE
Some bugs have been fixed

### DIFF
--- a/src/components/Overlays/Modal/Modal.tsx
+++ b/src/components/Overlays/Modal/Modal.tsx
@@ -51,7 +51,7 @@ export interface ModalProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onAnim
 
 type ModalWithComponents = ForwardRefExoticComponent<ModalProps & RefAttributes<HTMLDivElement>> & {
   Header: typeof ModalHeader;
-  Overlay: typeof Drawer.Overlay;
+  Overlay: typeof ModalOverlay;
   Close: typeof ModalClose;
 };
 
@@ -107,8 +107,12 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>(({
         <Drawer.Content
           ref={ref}
           className={classNames(styles.wrapper, className)}
+          aria-describedby={undefined}
           {...restProps}
         >
+          <VisuallyHidden>
+            <Drawer.Title />
+          </VisuallyHidden>
           {header}
           <div className={styles.body}>
             {children}

--- a/src/components/Service/AppRoot/hooks/useAppearance.ts
+++ b/src/components/Service/AppRoot/hooks/useAppearance.ts
@@ -9,8 +9,8 @@ import { getBrowserAppearanceSubscriber } from './helpers/getBrowserAppearanceSu
 import { getInitialAppearance } from './helpers/getInitialAppearance';
 
 export const useAppearance = (appearanceProp?: AppRootContextInterface['appearance']): NonNullable<AppRootContextInterface['appearance']> => {
-  const { appearance: contextAppearance } = useContext(AppRootContext);
-  const [appearance, setAppearance] = useState(appearanceProp || contextAppearance || getInitialAppearance());
+  const appContext = useContext(AppRootContext);
+  const [appearance, setAppearance] = useState(appearanceProp || appContext?.appearance || getInitialAppearance());
 
   const handleThemeChange = useCallback(() => {
     const telegramData = getTelegramData();


### PR DESCRIPTION
**Modal:**
A well-known [Modal error](https://github.com/Telegram-Mini-Apps/TelegramUI/pull/62), radix-ui has released an update where all these elements must be used in the Root component, because Context is used

**AppRoot/useAppearance:**
Could sometimes be called out of context, which caused a destructuring error.