### PR TITLE
Fix SegmentedControl: slider for Firefox and width overflow

### DIFF
--- a/src/components/Navigation/SegmentedControl/SegmentedControl.module.css
+++ b/src/components/Navigation/SegmentedControl/SegmentedControl.module.css
@@ -11,6 +11,7 @@
 
 .wrapper--fullWidth {
   width: 100%;
+  box-sizing: border-box;
 }
 
 .body {
@@ -35,7 +36,6 @@
   border-radius: 40px;
   transition: transform 150ms ease;
   width: 100%;
-  grid-column: span 1;
 }
 
 .wrapper--ios {


### PR DESCRIPTION
1) fixed bug slider bug in Firefox
2) fixed width overflow with fullWidth = true for ios/android

before/after
<img width="571" alt="image" src="https://github.com/user-attachments/assets/5fe5946b-193a-407c-bbb2-6291cfbb0f12" />
<img width="544" alt="image" src="https://github.com/user-attachments/assets/ee081969-d397-47fd-ac76-b2870f9b9c96" />

